### PR TITLE
Use full path when installing this plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 ## インストール(zplug)
 
 ```zshrc.zsh
-zplug "atnanasi/ttene.zsh", defer:2, \↲
-        hook-build:'magicalstick | grep -E "てねっ[0-9]+" | xargs -P4 -In1 wget n1 -P voices/'
+zplug "atnanasi/ttene.zsh", defer:2, \
+  hook-build:'magicalstick | grep -E "てねっ[0-9]+" | xargs -P4 -In1 wget n1 -P $ZPLUG_HOME/repos/atnanasi/ttene.zsh/voices/'
 ```
 
 注意点として


### PR DESCRIPTION
Thank you so much for creating the greatest Zsh plugin. I totally love this Zsh plugin but I encounter the error when I installing this plugin so I use the full path for `voices/` directory.